### PR TITLE
Clarify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ You can find the plugin at this [link](https://insomnia.rest/plugins/insomnia-pl
 
 ### Initialization
 - Create a new project from within insomnia
-- Configure the project as needed.
+- Configure the project as needed
 - Open workspace menu and select `Free sync: Configuration`
 - When file path is configured, workspace can be synchronized with `Save workspace` / `Load workspace` options
 
 ### Import
-- Import the previously exported workspace json file as new project.
+- Import the previously exported workspace json file as new project
 - Open workspace menu and select `Free sync: Configuration`
 - When file path is configured, workspace can be synchronized with `Save workspace` / `Load workspace` options
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ You can find the plugin at this [link](https://insomnia.rest/plugins/insomnia-pl
 ### How to use it
 
 - Install the plugin from the [Insomnia plugin Hub](https://insomnia.rest/plugins/insomnia-plugin-free-sync).
+
+### Initialization
+- Create a new project from within insomnia
+- Configure the project as needed.
+- Open workspace menu and select `Free sync: Configuration`
+- When file path is configured, workspace can be synchronized with `Save workspace` / `Load workspace` options
+
+### Import
+- Import the previously exported workspace json file as new project.
 - Open workspace menu and select `Free sync: Configuration`
 - When file path is configured, workspace can be synchronized with `Save workspace` / `Load workspace` options
 


### PR DESCRIPTION
I faced the issue to not be able to import an existing config with the error, that I am trying to import a file into the wrong collection. Via File selection it told me to override the file, pasting the path resulted in previous mentioned behaviour.

I needed to initially load the file to create the project via the native insomnia functionality.
Finally I could set up the sync with the configuration file.

I documented this workflow in the README.md so it will be easier for successors to set things up :).