### PR TITLE
Add necessary ids for initial import to metadata json.

### DIFF
--- a/src/services/workspace-service-multiple-files.ts
+++ b/src/services/workspace-service-multiple-files.ts
@@ -52,7 +52,12 @@ export class WorkspaceServiceMultipleFiles extends WorkspaceServiceBase {
       await writeFile(resourceFilePath, WorkspaceServiceBase.stringifyExportData(resource), {encoding: 'utf8'})
     }
 
-    data.resources = []
+    data.resources = data.resources.filter(x => x._id.startsWith('wrk') || (x._id.startsWith('spc') || (x._id.startsWith('env') && x.name === "Base Environment")))
+    data.resources.forEach(resource => {
+      if(resource?.contents) resource.contents = "";
+      if(resource?.data) resource.data = {};
+      if(resource?.dataPropertyOrder) resource.dataPropertyOrder = {};
+    })
     await writeFile(
       path.join(configuration.filePath!, WorkspaceServiceMultipleFiles.metaFileName),
       WorkspaceServiceBase.stringifyExportData(data), {encoding: 'utf8'},

--- a/src/services/workspace-service-multiple-files.ts
+++ b/src/services/workspace-service-multiple-files.ts
@@ -52,12 +52,18 @@ export class WorkspaceServiceMultipleFiles extends WorkspaceServiceBase {
       await writeFile(resourceFilePath, WorkspaceServiceBase.stringifyExportData(resource), {encoding: 'utf8'})
     }
 
-    data.resources = data.resources.filter(x => x._id.startsWith('wrk') || (x._id.startsWith('spc') || (x._id.startsWith('env') && x.name === "Base Environment")))
+    data.resources = data.resources.filter(x => 
+      x._id.startsWith('wrk') || 
+      x._id.startsWith('spc') || 
+      (x._id.startsWith('env') && x.name === "Base Environment")
+    )
+    
     data.resources.forEach(resource => {
       if(resource?.contents) resource.contents = "";
       if(resource?.data) resource.data = {};
       if(resource?.dataPropertyOrder) resource.dataPropertyOrder = {};
     })
+    
     await writeFile(
       path.join(configuration.filePath!, WorkspaceServiceMultipleFiles.metaFileName),
       WorkspaceServiceBase.stringifyExportData(data), {encoding: 'utf8'},


### PR DESCRIPTION
Thanks for adding my save as multiple files feature. I am going to hopefully get a lot of good use out of this plugin now. The only issue I have now is that the refactored code removed the part of the export where we save the ids for the base environment, api spec, and workspace. These are needed in order to load the meta.json as a design document, then loading the rest of the changes as the multiple files via the plugin. If these ids don't exist on the intial file import into insomnia:

-  insomnia will by default create a new base environment with a fresh id. This breaks the import of existing environments as they point to the original base environment id.
- insomnia will create a new api spec. This will result in many duplicate api specs upon each initial import then save export
- insomnia creates a new workspace id. This breaks the load feature entirely as you can't load a workspace without the same id as the saved workspace! 

This update will save the required base ids without their corresponding data making the import from file possible without breaking anything. Removing the content, data, and datapropertyorders is simply there to prevent extra unnecessary merge conflicts. Those properties are still saved, but in their corresponding file.

New format with ids and metadata for meta.json
`{
  "_type": "export",
  "__export_format": 4,
  "__export_date": "2023-03-21T15:20:09.622Z",
  "__export_source": "insomnia.desktop.app:v2023.1.0-beta.5",
  "resources": [
    {
      "_id": "wrk_ee8098de4703424290a77216e055073f",
      "parentId": null,
      "modified": 1673459402110,
      "created": 1673459402110,
      "name": "Example.yaml",
      "description": "",
      "scope": "design",
      "_type": "workspace"
    },
    {
      "_id": "env_103b2540f3eee6d74caaa227f79c70792ef3a879",
      "parentId": "wrk_ee8098de4703424290a77216e055073f",
      "modified": 1673459402113,
      "created": 1673459402113,
      "name": "Base Environment",
      "data": {},
      "dataPropertyOrder": {},
      "color": null,
      "isPrivate": false,
      "metaSortKey": 1673459402113,
      "_type": "environment"
    },
    {
      "_id": "spc_80895865a0054444b354c73691eddfa4",
      "parentId": "wrk_ee8098de4703424290a77216e055073f",
      "modified": 1673459402110,
      "created": 1673459402110,
      "fileName": "Example",
      "contents": "",
      "contentType": "yaml",
      "_type": "api_spec"
    }
  ]
}`